### PR TITLE
fix(zzz): 补充xpath边界情况，避免第一期卡池信息缺失

### DIFF
--- a/spider/spider/spiders/zzz_history.py
+++ b/spider/spider/spiders/zzz_history.py
@@ -14,7 +14,7 @@ class ZzzHistorySpider(scrapy.Spider):
     start_urls = ["https://wiki.biligame.com/zzz/%E8%B0%83%E9%A2%91"]
 
     def parse(self, response):
-        row_list = response.xpath('//*[@id="mw-content-text"]/div/h3[contains(., "第")]/following-sibling::table[following-sibling::h3]')
+        row_list = response.xpath('//*[@id="mw-content-text"]/div/h3[contains(., "第")]/following-sibling::table[following-sibling::h3 or not(following-sibling::*)]')
         # row_list = response.xpath('//*[@id="mw-content-text"]/div/table[@class="wikitable"]')
 
         # 每个版本


### PR DESCRIPTION
补充zzz卡池历史缺失的第一期卡池信息

另，此项目的[zzz历史记录文件](https://raw.githubusercontent.com/iaoongin/GachaClock/main/spider/data/zzz/history.json)将作为[ZZZ插件卡池查询功能](https://github.com/ZZZure/ZZZ-Plugin/pull/154)的数据源，感谢作者的付出 👍 